### PR TITLE
Use SIMD instructions for MatMul on CPU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,11 @@ rayon ={ version = "1.8" }
 rand ={ version = "*" }
 byteorder = { version = "1.5" }
 rand_chacha ={ version = "*" }
+wide = "0.7.13"
 
 [features]
 # default = ["gpu"]
-gpu = [
-    "dep:cudarc"
-]
+gpu = ["dep:cudarc"]
 
 [dependencies.cudarc]
 version = "*"

--- a/src/device/cpu.rs
+++ b/src/device/cpu.rs
@@ -35,9 +35,11 @@ impl Device<&mut [f32], &[f32], &[f32]> for CPU {
                 let mut v = f32x4::splat(0.0);
                 for k in (0..width).step_by(4) {
                     let a_wide = f32x4::from(&a[r * width + k..r * width + k + 4]);
-                    let b_wide = f32x4::from(&b[k * o_cols + c..k * o_cols + c + 4]);
+                    let b_values = [b[k * o_cols + c], b[(k + 1) * o_cols + c], b[(k + 2) * o_cols + c], b[(k + 3) * o_cols + c]];
+                    let b_wide = f32x4::from(&b_values[..]);
                     v += a_wide * b_wide;
                 }
+                // println!("v: {:?}", v);
                 *o = v.reduce_add();
 
             }
@@ -52,13 +54,11 @@ mod tests {
 
     #[test]
     fn test_matrix_mul() {
-        let a_host = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0];
-        let b_host = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0];
+        let a_host = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0, 0.0]; // padding with zeros
+        let b_host = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 0.0, 0.0]; // padding with zeros
         let mut c_host = vec![0.0f32; 4];
         let cpu = CPU {};
         let _ = &cpu.matmul(&mut c_host, &a_host, &b_host, 3, 2, 2);
         assert_eq!(c_host, [22.0, 28.0, 49.0, 64.0]);
-
     }
-
 }


### PR DESCRIPTION
## What?
Use SIMD instructions for MatMul on CPU

## Why?
For more performant matmul on CPU with SIMD support, it's better to utilize SIMD instructions. 

## Summary of results:
_On an M2 Macbook Pro_
| model/branch    | non-simd | simd | speedup |
|-----------------|----------|------|---------|
| stories15M.bin  | 178      | 233  | 1.3x    |
| stories110M.bin | 52       | 80.3 | 1.54x   |
| llama2-7b.bin   | 1.1      | 2.2  | 2x      |