### PR TITLE
Support quantization for Rama

### DIFF
--- a/engine/README.md
+++ b/engine/README.md
@@ -17,6 +17,12 @@ python export/export.py llama2_7b.bin --meta-llama path/to/llama/model/7B
 cargo run --release -- -m llama2_7b.bin -t tokenizer.bin -p 'once upon a time'
 ```
 
+pass `--q80` to enable quantization
+```
+python export.py llama2_7b_q80.bin --version 2 --meta-llama path/to/llama/model/7B
+cargo run --release --bin engine -- --model llama2_7b_q80.bin --tokenizer ./engine/tokenizer.bin --q80
+```
+
 pass `--features gpu` to use GPU for matrix multiplications
 ```
 cargo run --bin engine --features gpu --release -- -m llama2_7b.bin -t tokenizer.bin -p 'once upon a time'
@@ -75,6 +81,6 @@ Running llama2-7b f32 in M1 macbook is extremely slow since it requires 25GB mem
 - [x] Improve GPU performance to be at least slightly faster than CPU as baseline.
 - [x] Support CUBLAS for matmul.
 - [x] Support SIMD for CPU.
-- [ ] Support quantization.
+- [x] Support quantization.
 - [ ] Support flash attention.
 - [ ] Support AMD GPUs.

--- a/engine/export/export.py
+++ b/engine/export/export.py
@@ -274,6 +274,7 @@ def version2_export(model, filepath, group_size=64):
     while model.params.dim % group_size != 0:
         group_size //= 2
         print(f"BACKOFF: reducing group size to {group_size} to fit hidden_dim")
+    # model.layers = model.layers[:1]
     weights = [
         model.tok_embeddings.weight,
         *[layer.attention.wq.weight for layer in model.layers],
@@ -579,7 +580,7 @@ def model_export(model, filepath, version, dtype=torch.float32):
     v2: int8 quantized Q8_0 export, similar to llama.cpp, in groups
     # TODO: add dtype export support for other versions (?)
     """
-    if version == 0:
+c.vocab_size * c.dim    if version == 0:
         legacy_export(model, filepath)
     elif version == 1:
         version1_export(model, filepath)
@@ -627,7 +628,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("filepath", type=str, help="the output filepath")
-    parser.add_argument("--version", default=80, type=int, help="the version to export with")
+    parser.add_argument("--version", default=2, type=int, help="the version to export with")
     parser.add_argument("--dtype", type=str, help="dtype of the model (fp16, fp32)", default="fp32")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--checkpoint", type=str, help="model checkpoint, .pt file")

--- a/engine/export/export.py
+++ b/engine/export/export.py
@@ -507,8 +507,6 @@ def model_export(model, filepath, version, dtype=torch.float32):
         version1_export(model, filepath)
     elif version == 2:
         version2_export(model, filepath)
-    elif version == 80:
-        legacy_export_q80(model, filepath)
     elif version == -1:
         hf_export(model, filepath, dtype)
     else:
@@ -549,7 +547,7 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser()
     parser.add_argument("filepath", type=str, help="the output filepath")
-    parser.add_argument("--version", default=2, type=int, help="the version to export with")
+    parser.add_argument("--version", default=0, type=int, help="the version to export with")
     parser.add_argument("--dtype", type=str, help="dtype of the model (fp16, fp32)", default="fp32")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--checkpoint", type=str, help="model checkpoint, .pt file")

--- a/engine/src/device/cpu.rs
+++ b/engine/src/device/cpu.rs
@@ -89,7 +89,7 @@ fn test_matmul() {
     println!("{:?}", *qt_mut.data);
 }
 
-impl Device<Vec<f32>, Vec<f32>> for CPU {
+impl Device<Vec<f32>, Vec<QuantizedTensor>> for CPU {
 
     fn array_add(&self, target: &mut MutView<'_, Vec<f32>>, source: &View<'_, Vec<f32>>, _n: usize) {
         let s_range = source.range.clone();
@@ -98,7 +98,7 @@ impl Device<Vec<f32>, Vec<f32>> for CPU {
         .for_each(|(a, b)| *a += *b);
     }
 
-    fn multi_head_attention(&self, rsv: &mut RunStateView<'_, Vec<f32>, Vec<f32>>,
+    fn multi_head_attention(&self, rsv: &mut RunStateView<'_, Vec<f32>, Vec<QuantizedTensor>>,
                                 cfg: &Config,
                                 layer: usize,
                                 pos: usize,) {
@@ -229,7 +229,7 @@ impl Device<Vec<f32>, Vec<f32>> for CPU {
         );
     }
 
-    fn sample<'a>(&self, cfg: &Config, rsv: &mut RunStateView<'a, Vec<f32>, Vec<f32>>, temperature: f32, topp: f32) -> usize {
+    fn sample<'a>(&self, cfg: &Config, rsv: &mut RunStateView<'a, Vec<f32>, Vec<QuantizedTensor>>, temperature: f32, topp: f32) -> usize {
         let next;
 
         let lr = rsv.logits.range.clone();
@@ -255,7 +255,7 @@ impl Device<Vec<f32>, Vec<f32>> for CPU {
         next
     }
 
-    fn to_cpu(&self, _state: &RunStateView<Vec<f32>, Vec<f32>>, _cpu_state: &mut RunState<Vec<f32>, Vec<f32>>) {
+    fn to_cpu(&self, _state: &RunStateView<Vec<f32>, Vec<QuantizedTensor>>, _cpu_state: &mut RunState<Vec<f32>, Vec<f32>>) {
         // no need to do anything since it is already CPU.
     }
 }

--- a/engine/src/device/cpu.rs
+++ b/engine/src/device/cpu.rs
@@ -29,7 +29,7 @@ impl QuantDevice<Vec<f32>, Vec<QuantizedTensor>> for CPU {
                 let mut v = 0f32;
 
                 for k in 0..width {
-                    let pre_scale = aq.q[r * width + k] * bq.q[k * o_cols + c];
+                    let pre_scale = aq.q[r * width + k] as i32 * bq.q[k * o_cols + c] as i32;
                     v += pre_scale as f32 * aq.s[(r * width + k) / GS] * bq.s[(k * o_cols + c) / GS];
                 }
                 *o = v as f32;

--- a/engine/src/device/cpu.rs
+++ b/engine/src/device/cpu.rs
@@ -12,6 +12,16 @@ use super::device::{Device, QuantDevice};
 pub struct CPU {}
 
 const GS: usize = 64;
+
+impl QuantDevice<Vec<f32>, Vec<f32>> for CPU {
+    fn matmul_q(&self, o: &mut MutView<'_, Vec<f32>>, a: &View<'_, Vec<f32>>, b: &View<'_, Vec<f32>>, width: usize, o_rows: usize, o_cols: usize) {
+        // dummy
+    }
+
+    fn quantize(&self, o: &mut MutView<'_, Vec<f32>>, a: &View<'_, Vec<f32>>, n: usize) {
+        // dummy
+    }
+}
 impl QuantDevice<Vec<f32>, Vec<QuantizedTensor>> for CPU {
     fn matmul_q(&self, o: &mut MutView<'_, Vec<f32>>, a: &View<'_, Vec<QuantizedTensor>>, b: &View<'_, Vec<QuantizedTensor>>, width: usize, o_rows: usize, o_cols: usize) {
         let or = o.range.clone();
@@ -82,7 +92,7 @@ impl QuantDevice<Vec<f32>, Vec<QuantizedTensor>> for CPU {
     }
 }
 
-impl Device<Vec<f32>, Vec<QuantizedTensor>> for CPU {
+impl<Q: Storage> Device<Vec<f32>, Q> for CPU {
 
     fn array_add(&self, target: &mut MutView<'_, Vec<f32>>, source: &View<'_, Vec<f32>>, _n: usize) {
         let s_range = source.range.clone();
@@ -91,7 +101,7 @@ impl Device<Vec<f32>, Vec<QuantizedTensor>> for CPU {
         .for_each(|(a, b)| *a += *b);
     }
 
-    fn multi_head_attention(&self, rsv: &mut RunStateView<'_, Vec<f32>, Vec<QuantizedTensor>>,
+    fn multi_head_attention(&self, rsv: &mut RunStateView<'_, Vec<f32>, Q>,
                                 cfg: &Config,
                                 layer: usize,
                                 pos: usize,) {
@@ -252,7 +262,7 @@ impl Device<Vec<f32>, Vec<QuantizedTensor>> for CPU {
         );
     }
 
-    fn sample<'a>(&self, cfg: &Config, rsv: &mut RunStateView<'a, Vec<f32>, Vec<QuantizedTensor>>, temperature: f32, topp: f32) -> usize {
+    fn sample<'a>(&self, cfg: &Config, rsv: &mut RunStateView<'a, Vec<f32>, Q>, temperature: f32, topp: f32) -> usize {
         let next;
 
         let lr = rsv.logits.range.clone();
@@ -278,7 +288,7 @@ impl Device<Vec<f32>, Vec<QuantizedTensor>> for CPU {
         next
     }
 
-    fn to_cpu(&self, _state: &RunStateView<Vec<f32>, Vec<QuantizedTensor>>, _cpu_state: &mut RunState<Vec<f32>, Vec<f32>>) {
+    fn to_cpu(&self, _state: &RunStateView<Vec<f32>, Q>, _cpu_state: &mut RunState<Vec<f32>, Vec<f32>>) {
         // no need to do anything since it is already CPU.
     }
 }

--- a/engine/src/device/cpu.rs
+++ b/engine/src/device/cpu.rs
@@ -75,7 +75,7 @@ fn test_matmul() {
     println!("{:?}", *qt_mut.data);
 }
 
-impl Device<Vec<f32>> for CPU {
+impl Device<Vec<f32>, Vec<f32>> for CPU {
 
     fn array_add(&self, target: &mut MutView<'_, Vec<f32>>, source: &View<'_, Vec<f32>>, _n: usize) {
         let s_range = source.range.clone();

--- a/engine/src/device/cpu.rs
+++ b/engine/src/device/cpu.rs
@@ -300,31 +300,6 @@ impl CPU {
         let sum = x.par_iter().sum::<f32>();
         x.par_iter_mut().for_each(|a| *a /= sum);
     }
-
-    #[allow(dead_code)]
-    fn matmul_test(&self, o: &mut MutView<'_, Vec<f32>>, a: &View<'_, Vec<f32>>, b: &View<'_, Vec<f32>>, width: usize, _o_rows: usize, o_cols: usize)
-    {
-        let or = o.range.clone();
-        let o = &mut o.as_mut()[or];
-
-        let ar = a.range.clone();
-        let a = &a.as_ref()[ar];
-
-        let br = b.range.clone();
-        let b = &b.as_ref()[br];
-        o.par_iter_mut().enumerate().for_each(
-            |(idx, o)| {
-                let r = idx / o_cols;
-                let c = idx % o_cols;
-                let mut v = 0.0;
-                for k in 0..width {
-                    v += a[r * width + k] * b[k * o_cols + c];
-                }
-                *o = v;
-            }
-
-        );
-    }
 }
 
 

--- a/engine/src/device/cpu.rs
+++ b/engine/src/device/cpu.rs
@@ -14,16 +14,16 @@ pub struct CPU {}
 const GS: usize = 64;
 
 impl QuantDevice<Vec<f32>, Vec<f32>> for CPU {
-    fn matmul_q(&self, o: &mut MutView<'_, Vec<f32>>, a: &View<'_, Vec<f32>>, b: &View<'_, Vec<f32>>, width: usize, o_rows: usize, o_cols: usize) {
+    fn matmul_q(&self, _: &mut MutView<'_, Vec<f32>>, _: &View<'_, Vec<f32>>, _: &View<'_, Vec<f32>>, _: usize, _: usize, _: usize) {
         // dummy
     }
 
-    fn quantize(&self, o: &mut MutView<'_, Vec<f32>>, a: &View<'_, Vec<f32>>, n: usize) {
+    fn quantize(&self, _: &mut MutView<'_, Vec<f32>>, _: &View<'_, Vec<f32>>, _: usize) {
         // dummy
     }
 }
 impl QuantDevice<Vec<f32>, Vec<QuantizedTensor>> for CPU {
-    fn matmul_q(&self, o: &mut MutView<'_, Vec<f32>>, a: &View<'_, Vec<QuantizedTensor>>, b: &View<'_, Vec<QuantizedTensor>>, width: usize, o_rows: usize, o_cols: usize) {
+    fn matmul_q(&self, o: &mut MutView<'_, Vec<f32>>, a: &View<'_, Vec<QuantizedTensor>>, b: &View<'_, Vec<QuantizedTensor>>, width: usize, _: usize, o_cols: usize) {
         let or = o.range.clone();
         let o = &mut o.as_mut()[or];
 

--- a/engine/src/device/device.rs
+++ b/engine/src/device/device.rs
@@ -23,7 +23,7 @@ pub trait Device<T: Storage, Q: Storage> {
 
 // A quant device deals with QuantTensors. It takes quantized tensors as input and returns dequantized output
 // The only function that deals with quans stuff is matrix multiplication.
-pub trait QuantDevice<T: Storage, Q: Storage> {
+pub trait QuantDevice<T: Storage, Q: Storage>: Device<T, Q> {
     fn matmul_q(&self, o: &mut MutView<'_, T>, a: &View<'_, Q>, b: &View<'_, Q>, width: usize, o_rows: usize, o_cols: usize);
     fn quantize(&self, o: &mut MutView<'_, Q>, a: &View<'_, T>, n: usize);
 }

--- a/engine/src/device/device.rs
+++ b/engine/src/device/device.rs
@@ -25,4 +25,5 @@ pub trait Device<T: Storage, Q: Storage> {
 // The only function that deals with quans stuff is matrix multiplication.
 pub trait QuantDevice<T: Storage, Q: Storage> {
     fn matmul_q(&self, o: &mut MutView<'_, T>, a: &View<'_, Q>, b: &View<'_, Q>, width: usize, o_rows: usize, o_cols: usize);
+    fn quantize(&self, o: &mut MutView<'_, Q>, a: &View<'_, T>, n: usize);
 }

--- a/engine/src/device/device.rs
+++ b/engine/src/device/device.rs
@@ -9,6 +9,8 @@ pub trait Device<T: Storage, Q: Storage> {
     fn copy_from_slice(&self, target: &mut MutView<'_, T>, source: &View<'_, T>, n: usize);
     fn rmsnorm(&self, o: &mut MutView<'_, T>, x: &View<'_, T>,
                         weight: &View<'_, T>, n: usize);
+    fn apply_rope(&self, q: &mut MutView<'_, T>, k: &mut MutView<'_, T>,
+        pos: usize, dim: usize, kv_dim: usize, head_size: usize);
     fn apply_position(&self, q: &mut MutView<'_, T>, k: &mut MutView<'_, T>, pos_real: &View<'_, T>, pos_img: &View<'_, T>, head_size: usize);
     fn matmul(&self, o: &mut MutView<'_, T>, a: &View<'_, T>, b: &View<'_, T>, width: usize, o_rows: usize, o_cols: usize);
     fn softmax<'a>(&self, x: &mut MutView<'a, T>, n: usize);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -63,7 +63,7 @@ pub struct EngineService {
 
     // Weights of the model in CPU memory.
     #[cfg(not(feature="gpu"))]
-    weights: TransformerWeights<Vec<f32>>,
+    weights: TransformerWeights<Vec<f32>, Vec<f32>>,
     #[cfg(feature="gpu")]
     weights: TransformerWeights<CudaSlice<f32>>,
 
@@ -149,7 +149,7 @@ async fn handler() {
                     let step = es.eng_config.step;
                     let temperature = es.eng_config.temperature;
                     let topp = es.eng_config.topp;
-                    transformer::generate_stream(&es.model_config, &es.tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &es.device, cr.sender).await;
+                    transformer::generate_stream::<Vec<f32>, Vec<f32>, CPU>(&es.model_config, &es.tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &es.device, cr.sender).await;
                 });
             },
             Err(_) => {

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -136,7 +136,7 @@ async fn handler() {
                     println!("received prompt --> {}", prompt);
 
                     #[cfg(not(feature="gpu"))]
-                    let wv = TransformerWeightsView::from_ws(&es.weights);
+                    let wv = TransformerWeightsView::<Vec<f32>, Vec<f32>>::from_ws(&es.weights);
 
                     #[cfg(feature="gpu")]
                     let mut state = RunState::from_state(&mut state, &es.device);

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -94,7 +94,7 @@ impl EngineService {
         let token_path = eng_config.tokenizer.clone();
 
         let rd = &mut BufReader::new(File::open(path).unwrap());
-        let model_config = Config::from_file(rd);
+        let model_config = Config::from_file_v1(rd);
 
         #[allow(unused_variables)]
         let device: CPU = CPU {};
@@ -131,7 +131,7 @@ async fn handler() {
             Ok(cr) => {
                 // allocate RunState space.
                 tokio::spawn(async {
-                    let mut state = RunState::from_config(&es.model_config);
+                    let mut state = RunState::<Vec<f32>, Vec<f32>>::from_config(&es.model_config);
                     let prompt = cr.prompt;
                     println!("received prompt --> {}", prompt);
 

--- a/engine/src/lib.rs
+++ b/engine/src/lib.rs
@@ -102,7 +102,7 @@ impl EngineService {
         let device = GPU::new();
 
         #[allow(unused_mut)]
-        let mut weights = TransformerWeights::from_file(rd, &model_config);
+        let mut weights = TransformerWeights::<Vec<f32>, Vec<f32>>::from_file(rd, &model_config);
         #[cfg(feature="gpu")]
         let weights = TransformerWeights::from_weight(&mut weights, &device);
 
@@ -149,7 +149,7 @@ async fn handler() {
                     let step = es.eng_config.step;
                     let temperature = es.eng_config.temperature;
                     let topp = es.eng_config.topp;
-                    transformer::generate_stream::<Vec<f32>, Vec<f32>, CPU>(&es.model_config, &es.tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &es.device, cr.sender).await;
+                    // transformer::generate_stream::<Vec<f32>, Vec<QuantizedTensor>, CPU>(&es.model_config, &es.tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &es.device, cr.sender).await;
                 });
             },
             Err(_) => {

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
         let mut state = RunState::from_state(&mut state, &device);
 
         #[cfg(not(feature="gpu"))]
-        let wv = TransformerWeightsView::from_ws(&weights);
+        let wv = TransformerWeightsView::from_ws_q(&weights);
         #[cfg(feature="gpu")]
         let wv = TransformerWeightsView::from_gpu_ws(&weights);
 
@@ -128,7 +128,7 @@ fn main() {
         let mut state = RunState::from_state(&mut state, &device);
 
         #[cfg(not(feature="gpu"))]
-        let wv = TransformerWeightsView::from_ws(&weights);
+        let wv = TransformerWeightsView::<Vec<f32>, Vec<f32>>::from_ws(&weights);
         #[cfg(feature="gpu")]
         let wv = TransformerWeightsView::from_gpu_ws(&weights);
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -66,7 +66,12 @@ fn main() {
     let topp = args.topp;
 
     let rd = &mut BufReader::new(File::open(path).unwrap());
+
     let config = Config::from_file(rd);
+
+    // Reset cursor at 256.
+    let rd = &mut BufReader::new(File::open(path).unwrap());
+    rd.seek_relative(256).unwrap();
 
     #[allow(unused_variables)]
     let device = CPU {};

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -48,6 +48,10 @@ struct Args {
     /// (optional) Mode: generate or chat.
     #[arg(short('o'), long, default_value = "generate")]
     mode: String,
+
+    /// (optional) Mode: generate or chat.
+    #[arg(short('q'), long, default_value_t = false)]
+    q80: bool,
 }
 
 // Options:
@@ -57,6 +61,7 @@ struct Args {
 //   -s, --step <STEP>                Number of steps to run [default: 1]
 //   -r, --temperature <TEMPERATURE>  Path to the model checkpoint file [default: 0.9]
 //   -h, --help                       Print help
+//   -q, --q80                        whether checkpoint is quantized.
 //   -V, --version                    Print version
 
 fn main() {
@@ -64,49 +69,85 @@ fn main() {
     let path = &args.model;
     let token_path = &args.tokenizer;
     let topp = args.topp;
-
-    let rd = &mut BufReader::new(File::open(path).unwrap());
-
-    let config = Config::from_file(rd);
-
-    // Reset cursor at 256.
-    let rd = &mut BufReader::new(File::open(path).unwrap());
-    rd.seek_relative(256).unwrap();
+    let quantized = args.q80;
 
     #[allow(unused_variables)]
     let device = CPU {};
     #[cfg(feature="gpu")]
     let device = GPU::new();
 
-    #[allow(unused_mut)]
-    let mut weights = TransformerWeights::<Vec<f32>, Vec<QuantizedTensor>>::from_file(rd, &config);
-    #[cfg(feature="gpu")]
-    let weights = TransformerWeights::from_weight(&mut weights, &device);
-    let mut state = RunState::from_config(&config);
+    // Branch based on wether the model is quantized. Currently we take the input from the arg, technically we can directly get this from the model itself.
+    if quantized {
+        let rd = &mut BufReader::new(File::open(path).unwrap());
 
-    #[cfg(feature="gpu")]
-    let mut state = RunState::from_state(&mut state, &device);
+        let config = Config::from_file_v2(rd);
 
-    #[cfg(not(feature="gpu"))]
-    let wv = TransformerWeightsView::from_ws(&weights);
-    #[cfg(feature="gpu")]
-    let wv = TransformerWeightsView::from_gpu_ws(&weights);
+        // Reset cursor at 256.
+        let rd = &mut BufReader::new(File::open(path).unwrap());
+        rd.seek_relative(256).unwrap();
+        #[allow(unused_mut)]
+        let mut weights = TransformerWeights::<Vec<f32>, Vec<QuantizedTensor>>::from_file(rd, &config);
+        #[cfg(feature="gpu")]
+        let weights = TransformerWeights::from_weight(&mut weights, &device);
+        let mut state = RunState::<Vec<f32>, Vec<QuantizedTensor>>::from_config(&config);
 
-    let mut rsv = RunStateView::from_rs(&mut state);
+        #[cfg(feature="gpu")]
+        let mut state = RunState::from_state(&mut state, &device);
 
-    let step = args.step;
-    let prompt = args.prompt;
-    let temperature = args.temperature;
-    let tokenizer = Tokenizer::new(token_path, config.vocab_size).unwrap();
+        #[cfg(not(feature="gpu"))]
+        let wv = TransformerWeightsView::from_ws(&weights);
+        #[cfg(feature="gpu")]
+        let wv = TransformerWeightsView::from_gpu_ws(&weights);
 
-    let start: SystemTime = SystemTime::now();
+        let mut rsv = RunStateView::from_rs(&mut state);
 
-    let _ = transformer::generate::<Vec<f32>, Vec<QuantizedTensor>, CPU>(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
-    let elapsed = start.elapsed().unwrap();
-    println!("\n--------------------------------");
-    println!("elapsed: {}.{:03} s, avg tok/s: {}",
-            elapsed.as_secs(), elapsed.subsec_millis(),
-            (step - 1) as f32 / elapsed.as_secs_f32());
+        let step = args.step;
+        let prompt = args.prompt;
+        let temperature = args.temperature;
+        let tokenizer = Tokenizer::new(token_path, config.vocab_size).unwrap();
+
+        let start: SystemTime = SystemTime::now();
+
+        let _ = transformer::generate::<Vec<f32>, Vec<QuantizedTensor>, CPU>(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
+        let elapsed = start.elapsed().unwrap();
+        println!("\n--------------------------------");
+        println!("elapsed: {}.{:03} s, avg tok/s: {}",
+                elapsed.as_secs(), elapsed.subsec_millis(),
+                (step - 1) as f32 / elapsed.as_secs_f32());
+    } else {
+        let rd = &mut BufReader::new(File::open(path).unwrap());
+
+        let config = Config::from_file_v1(rd);
+        #[allow(unused_mut)]
+        let mut weights = TransformerWeights::<Vec<f32>, Vec<f32>>::from_file(rd, &config);
+        #[cfg(feature="gpu")]
+        let weights = TransformerWeights::from_weight(&mut weights, &device);
+        let mut state = RunState::<Vec<f32>, Vec<f32>>::from_config(&config);
+
+        #[cfg(feature="gpu")]
+        let mut state = RunState::from_state(&mut state, &device);
+
+        #[cfg(not(feature="gpu"))]
+        let wv = TransformerWeightsView::from_ws(&weights);
+        #[cfg(feature="gpu")]
+        let wv = TransformerWeightsView::from_gpu_ws(&weights);
+
+        let mut rsv = RunStateView::from_rs(&mut state);
+
+        let step = args.step;
+        let prompt = args.prompt;
+        let temperature = args.temperature;
+        let tokenizer = Tokenizer::new(token_path, config.vocab_size).unwrap();
+
+        let start: SystemTime = SystemTime::now();
+
+        let _ = transformer::generate::<Vec<f32>, Vec<f32>, CPU>(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
+        let elapsed = start.elapsed().unwrap();
+        println!("\n--------------------------------");
+        println!("elapsed: {}.{:03} s, avg tok/s: {}",
+                elapsed.as_secs(), elapsed.subsec_millis(),
+                (step - 1) as f32 / elapsed.as_secs_f32());
+    }
 
 }
 

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -95,7 +95,7 @@ fn main() {
 
     let start: SystemTime = SystemTime::now();
 
-    let _ = transformer::generate(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
+    let _ = transformer::generate::<Vec<f32>, Vec<f32>, CPU>(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
     let elapsed = start.elapsed().unwrap();
     println!("\n--------------------------------");
     println!("elapsed: {}.{:03} s, avg tok/s: {}",

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use device::cpu::CPU;
 
+use transformer::ram_q80::QuantizedTensor;
 use tokenizer::bpe::Tokenizer;
 #[cfg(feature="gpu")]
 use device::gpu::GPU;
@@ -73,7 +74,7 @@ fn main() {
     let device = GPU::new();
 
     #[allow(unused_mut)]
-    let mut weights = TransformerWeights::from_file(rd, &config);
+    let mut weights = TransformerWeights::<Vec<f32>, Vec<QuantizedTensor>>::from_file(rd, &config);
     #[cfg(feature="gpu")]
     let weights = TransformerWeights::from_weight(&mut weights, &device);
     let mut state = RunState::from_config(&config);
@@ -95,7 +96,7 @@ fn main() {
 
     let start: SystemTime = SystemTime::now();
 
-    let _ = transformer::generate::<Vec<f32>, Vec<f32>, CPU>(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
+    let _ = transformer::generate::<Vec<f32>, Vec<QuantizedTensor>, CPU>(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
     let elapsed = start.elapsed().unwrap();
     println!("\n--------------------------------");
     println!("elapsed: {}.{:03} s, avg tok/s: {}",

--- a/engine/src/main.rs
+++ b/engine/src/main.rs
@@ -108,7 +108,7 @@ fn main() {
 
         let start: SystemTime = SystemTime::now();
 
-        let _ = transformer::generate::<Vec<f32>, Vec<QuantizedTensor>, CPU>(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
+        let _ = transformer::generate_q::<Vec<f32>, Vec<QuantizedTensor>, CPU>(&config, &tokenizer, prompt, temperature, step.into(), topp, &wv, &mut rsv, &device);
         let elapsed = start.elapsed().unwrap();
         println!("\n--------------------------------");
         println!("elapsed: {}.{:03} s, avg tok/s: {}",

--- a/engine/src/transformer/infer.rs
+++ b/engine/src/transformer/infer.rs
@@ -5,7 +5,7 @@ use crate::device::device::{Device, QuantDevice};
 
 use super::{state::{RunStateView, TransformerWeightsView}, Config, Storage};
 
-pub fn forward<'a, T: Storage, Q: Storage, D: Device<T, T>>(cfg: &Config, wv: &TransformerWeightsView<'a, T, T>, rsv: &mut RunStateView<'a, T, T>, token: usize, pos: usize,  device: &D) {
+pub fn forward<'a, T: Storage, Q: Storage, D: Device<T, Q>>(cfg: &Config, wv: &TransformerWeightsView<'a, T, T>, rsv: &mut RunStateView<'a, T, Q>, token: usize, pos: usize,  device: &D) {
     // let mut cpu_state = RunState::from_config(&cfg); // for debugging
     let dim: usize = cfg.dim;
     let hidden_dim = cfg.hidden_dim;

--- a/engine/src/transformer/infer.rs
+++ b/engine/src/transformer/infer.rs
@@ -58,10 +58,8 @@ pub fn forward_q<'a, T: Storage, Q: Storage, D: Device<T, Q> + QuantDevice<T, Q>
     let dim: usize = cfg.dim;
     let hidden_dim = cfg.hidden_dim;
     let head_size = dim / cfg.n_heads;
+    let kv_dim = (dim * cfg.n_kv_heads) / cfg.n_heads;
     device.copy_from_slice(&mut rsv.x, &wv.token_embedding_table.slice(token * dim..((token + 1) * cfg.dim)), dim);
-
-    let pos_real = wv.freq_cis_real.slice(pos * (head_size / 2)..);
-    let pos_img = wv.freq_cis_imag.slice(pos * (head_size / 2)..);
 
     for layer in 0..cfg.n_layers {
         device.rmsnorm(&mut rsv.xb, &rsv.x.as_view(), &wv.rms_att_weight.slice(layer * dim..), dim);
@@ -69,25 +67,20 @@ pub fn forward_q<'a, T: Storage, Q: Storage, D: Device<T, Q> + QuantDevice<T, Q>
         device.quantize(&mut rsv.xq, &rsv.xb.as_view(), dim);
 
         device.matmul_q(&mut rsv.q, &wv.wq.slice(layer..layer + 1), &rsv.xq.as_view(), dim, dim, 1);
-        device.matmul_q(&mut rsv.k, &wv.wk.slice(layer..layer + 1), &rsv.xq.as_view(), dim, dim, 1);
-        device.matmul_q(&mut rsv.v, &wv.wv.slice(layer..layer + 1), &rsv.xq.as_view(), dim, dim, 1);
+        device.matmul_q(&mut rsv.k, &wv.wk.slice(layer..layer + 1), &rsv.xq.as_view(), dim, kv_dim, 1);
+        device.matmul_q(&mut rsv.v, &wv.wv.slice(layer..layer + 1), &rsv.xq.as_view(), dim, kv_dim, 1);
 
+        device.apply_rope(&mut rsv.q, &mut rsv.k, pos, dim, kv_dim, head_size);
 
-        for h in 0..cfg.n_heads {
-            let q = &mut rsv.q.mut_slice(h * head_size..);
-            let k = &mut rsv.k.mut_slice(h * head_size..);
-            device.apply_position(q, k, &pos_real, &pos_img, head_size);
-        }
-
-        let lo = layer * cfg.seq_len * dim;
-        device.copy_from_slice(&mut rsv.key_cache.mut_slice(lo + pos * dim..(lo + (pos + 1) * dim)), &rsv.k.as_view(), dim);
-        device.copy_from_slice(&mut rsv.value_cache.mut_slice(lo + pos * dim..(lo + (pos + 1) * dim)), &rsv.v.as_view(), dim);
+        let lo = layer * cfg.seq_len * kv_dim;
+        device.copy_from_slice(&mut rsv.key_cache.mut_slice(lo + pos * kv_dim..(lo + (pos + 1) * kv_dim)), &rsv.k.as_view(), kv_dim);
+        device.copy_from_slice(&mut rsv.value_cache.mut_slice(lo + pos * kv_dim..(lo + (pos + 1) * kv_dim)), &rsv.v.as_view(), kv_dim);
         device.multi_head_attention(rsv, &cfg, layer, pos);
 
         // Quantize xb for output of the attention
         device.quantize(&mut rsv.xq, &rsv.xb.as_view(), dim);
 
-        device.matmul_q(&mut rsv.xb2, &wv.wo.slice(layer * dim * dim..), &rsv.xq.as_view(), dim, dim, 1);
+        device.matmul_q(&mut rsv.xb2, &wv.wo.slice(layer..layer + 1), &rsv.xq.as_view(), dim, dim, 1);
 
         device.array_add(&mut rsv.x, &rsv.xb2.as_view(), dim);
 
@@ -96,16 +89,16 @@ pub fn forward_q<'a, T: Storage, Q: Storage, D: Device<T, Q> + QuantDevice<T, Q>
         // Quantize again
         device.quantize(&mut rsv.xq, &rsv.xb.as_view(), dim);
 
-        device.matmul_q(&mut rsv.hb, &wv.w1.slice(layer * hidden_dim * dim..), &rsv.xq.as_view(), dim, hidden_dim, 1);
-        device.matmul_q(&mut rsv.hb2, &wv.w3.slice(layer * hidden_dim * dim..), &rsv.xq.as_view(), dim, hidden_dim, 1);
+        device.matmul_q(&mut rsv.hb, &wv.w1.slice(layer..layer + 1), &rsv.xq.as_view(), dim, hidden_dim, 1);
+        device.matmul_q(&mut rsv.hb2, &wv.w3.slice(layer..layer + 1), &rsv.xq.as_view(), dim, hidden_dim, 1);
 
         device.sinu(&mut rsv.hb, hidden_dim);
 
+        device.array_mult(&mut rsv.hb, &rsv.hb2.as_view(), hidden_dim);
+
         // Quantize before matmul
         device.quantize(&mut rsv.hq, &rsv.hb.as_view(), hidden_dim);
-
-        device.array_mult(&mut rsv.hb, &rsv.hb2.as_view(), hidden_dim);
-        device.matmul_q(&mut rsv.xb, &wv.w2.slice(layer * dim * hidden_dim..), &rsv.hq.as_view(), hidden_dim, dim, 1);
+        device.matmul_q(&mut rsv.xb, &wv.w2.slice(layer..layer + 1), &rsv.hq.as_view(), hidden_dim, dim, 1);
         device.array_add(&mut rsv.x, &rsv.xb.as_view(), dim);
     }
     device.copy_from_slice(&mut rsv.xb, &rsv.x.as_view(), dim);
@@ -137,7 +130,8 @@ pub fn sample_top_q(probabilities: &[f32], num: usize, topp: f32, rng: &mut ChaC
         }
     }
 
-    let r = rng.gen::<f32>() * cum_prob;
+    let rand = rng.gen::<f32>();
+    let r = rand * cum_prob;
     let mut cdf = 0.0f32;
 
     for i in 0..last_index {

--- a/engine/src/transformer/infer.rs
+++ b/engine/src/transformer/infer.rs
@@ -1,11 +1,11 @@
 use rand::Rng;
 use rand_chacha::ChaCha20Rng;
 
-use crate::device::device::Device;
+use crate::device::device::{Device, QuantDevice};
 
 use super::{state::{RunStateView, TransformerWeightsView}, Config, Storage};
 
-pub fn forward<'a, T: Storage, D: Device<T>>(cfg: &Config, wv: &TransformerWeightsView<'a, T>, rsv: &mut RunStateView<'a, T>, token: usize, pos: usize,  device: &D) {
+pub fn forward<'a, T: Storage, D: Device<T>>(cfg: &Config, wv: &TransformerWeightsView<'a, T>, rsv: &mut RunStateView<'a, T, T>, token: usize, pos: usize,  device: &D) {
     // let mut cpu_state = RunState::from_config(&cfg); // for debugging
     let dim: usize = cfg.dim;
     let hidden_dim = cfg.hidden_dim;
@@ -17,7 +17,6 @@ pub fn forward<'a, T: Storage, D: Device<T>>(cfg: &Config, wv: &TransformerWeigh
 
     for layer in 0..cfg.n_layers {
         device.rmsnorm(&mut rsv.xb, &rsv.x.as_view(), &wv.rms_att_weight.slice(layer * dim..), dim);
-        device.matmul(&mut rsv.q, &wv.wq.slice(layer * dim * dim..), &rsv.xb.as_view(), dim, dim, 1);
         device.matmul(&mut rsv.q, &wv.wq.slice(layer * dim * dim..), &rsv.xb.as_view(), dim, dim, 1);
         device.matmul(&mut rsv.k, &wv.wk.slice(layer * dim * dim..), &rsv.xb.as_view(), dim, dim, 1);
         device.matmul(&mut rsv.v, &wv.wv.slice(layer * dim * dim..), &rsv.xb.as_view(), dim, dim, 1);
@@ -49,6 +48,54 @@ pub fn forward<'a, T: Storage, D: Device<T>>(cfg: &Config, wv: &TransformerWeigh
     device.copy_from_slice(&mut rsv.xb, &rsv.x.as_view(), dim);
     device.rmsnorm(&mut rsv.x, &rsv.xb.as_view(), &wv.rms_final_weight, dim);
     device.matmul(&mut rsv.logits, &wv.wcls, &rsv.x.as_view(), dim, cfg.vocab_size, 1);
+
+}
+
+// Quantized version of forward pass. The difference is mostly around quantization/dequantization
+// before matrix multiplication. Likely can be refactored later.
+pub fn forward_q<'a, T: Storage, Q: Storage, D: Device<T> + QuantDevice<T, Q>>(cfg: &Config, wv: &TransformerWeightsView<'a, T>, rsv: &mut RunStateView<'a, T, Q>, token: usize, pos: usize,  device: &D) {
+    // let mut cpu_state = RunState::from_config(&cfg); // for debugging
+    let dim: usize = cfg.dim;
+    let hidden_dim = cfg.hidden_dim;
+    let head_size = dim / cfg.n_heads;
+    device.copy_from_slice(&mut rsv.x, &wv.token_embedding_table.slice(token * dim..((token + 1) * cfg.dim)), dim);
+
+    let pos_real = wv.freq_cis_real.slice(pos * (head_size / 2)..);
+    let pos_img = wv.freq_cis_imag.slice(pos * (head_size / 2)..);
+
+    for layer in 0..cfg.n_layers {
+        device.rmsnorm(&mut rsv.xb, &rsv.x.as_view(), &wv.rms_att_weight.slice(layer * dim..), dim);
+        device.matmul_q(&mut rsv.q, &wv.wq.slice(layer * dim * dim..), &rsv.xb.as_view(), dim, dim, 1);
+        device.matmul_q(&mut rsv.k, &wv.wk.slice(layer * dim * dim..), &rsv.xb.as_view(), dim, dim, 1);
+        device.matmul_q(&mut rsv.v, &wv.wv.slice(layer * dim * dim..), &rsv.xb.as_view(), dim, dim, 1);
+
+        for h in 0..cfg.n_heads {
+            let q = &mut rsv.q.mut_slice(h * head_size..);
+            let k = &mut rsv.k.mut_slice(h * head_size..);
+            device.apply_position(q, k, &pos_real, &pos_img, head_size);
+        }
+
+        let lo = layer * cfg.seq_len * dim;
+        device.copy_from_slice(&mut rsv.key_cache.mut_slice(lo + pos * dim..(lo + (pos + 1) * dim)), &rsv.k.as_view(), dim);
+        device.copy_from_slice(&mut rsv.value_cache.mut_slice(lo + pos * dim..(lo + (pos + 1) * dim)), &rsv.v.as_view(), dim);
+        device.multi_head_attention(rsv, &cfg, layer, pos);
+        device.matmul(&mut rsv.xb2, &wv.wo.slice(layer * dim * dim..), &rsv.xb.as_view(), dim, dim, 1);
+
+        device.array_add(&mut rsv.x, &rsv.xb2.as_view(), dim);
+
+        device.rmsnorm(&mut rsv.xb, &rsv.x.as_view(), &wv.rms_ffn_weight.slice(layer * dim..), dim);
+
+        device.matmul_q(&mut rsv.hb, &wv.w1.slice(layer * hidden_dim * dim..), &rsv.xb.as_view(), dim, hidden_dim, 1);
+        device.matmul_q(&mut rsv.hb2, &wv.w3.slice(layer * hidden_dim * dim..), &rsv.xb.as_view(), dim, hidden_dim, 1);
+
+        device.sinu(&mut rsv.hb, hidden_dim);
+        device.array_mult(&mut rsv.hb, &rsv.hb2.as_view(), hidden_dim);
+        device.matmul_q(&mut rsv.xb, &wv.w2.slice(layer * dim * hidden_dim..), &rsv.hb.as_view(), hidden_dim, dim, 1);
+        device.array_add(&mut rsv.x, &rsv.xb.as_view(), dim);
+    }
+    device.copy_from_slice(&mut rsv.xb, &rsv.x.as_view(), dim);
+    device.rmsnorm(&mut rsv.x, &rsv.xb.as_view(), &wv.rms_final_weight, dim);
+    device.matmul_q(&mut rsv.logits, &wv.wcls, &rsv.x.as_view(), dim, cfg.vocab_size, 1);
 
 }
 

--- a/engine/src/transformer/infer.rs
+++ b/engine/src/transformer/infer.rs
@@ -66,12 +66,11 @@ pub fn forward_q<'a, T: Storage, Q: Storage, D: Device<T, Q> + QuantDevice<T, Q>
     for layer in 0..cfg.n_layers {
         device.rmsnorm(&mut rsv.xb, &rsv.x.as_view(), &wv.rms_att_weight.slice(layer * dim..), dim);
 
-        // TODO QUANTIZE
         device.quantize(&mut rsv.xq, &rsv.xb.as_view(), dim);
 
         device.matmul_q(&mut rsv.q, &wv.wq.slice(layer..layer + 1), &rsv.xq.as_view(), dim, dim, 1);
-        device.matmul_q(&mut rsv.k, &wv.wk.slice(layer * dim * dim..), &rsv.xq.as_view(), dim, dim, 1);
-        device.matmul_q(&mut rsv.v, &wv.wv.slice(layer * dim * dim..), &rsv.xq.as_view(), dim, dim, 1);
+        device.matmul_q(&mut rsv.k, &wv.wk.slice(layer..layer + 1), &rsv.xq.as_view(), dim, dim, 1);
+        device.matmul_q(&mut rsv.v, &wv.wv.slice(layer..layer + 1), &rsv.xq.as_view(), dim, dim, 1);
 
 
         for h in 0..cfg.n_heads {

--- a/engine/src/transformer/mod.rs
+++ b/engine/src/transformer/mod.rs
@@ -143,8 +143,16 @@ pub struct Config {
 
 impl Config {
     pub fn from_file(f: &mut BufReader<File>) -> Self {
-        let mut shared_weight = false;
-        let c  = Self {
+        let magic = read::<u32>(f);
+        println!("0x{:x}", magic);
+        io::stdout().flush().unwrap();
+
+        assert_eq!(magic, 1634415666);
+
+        let version = read::<u32>(f);
+        assert_eq!(version, 2);
+
+        let mut c  = Self {
 
             dim: read::<i32>(f) as usize,
             hidden_dim: read::<i32>(f) as usize,
@@ -154,7 +162,7 @@ impl Config {
             vocab_size: {
                 let vocab = read::<i32>(f);
                 if vocab > 0 {
-                    shared_weight = true;
+                    true;
                     vocab as usize
                 } else {
                     vocab.abs() as usize
@@ -164,8 +172,11 @@ impl Config {
             shared_weight: false,
             is_quantized: false,
         };
+        c.n_layers = 1;
+        let shared_weight = read_byte(f) != 0;
+        let _ = read::<i32>(f);
         Self {
-            shared_weight: shared_weight,
+            shared_weight,
             ..c
         }
     }

--- a/engine/src/transformer/mod.rs
+++ b/engine/src/transformer/mod.rs
@@ -1,6 +1,7 @@
 #[cfg(feature = "gpu")]
 pub mod hbm;
 pub mod ram;
+pub mod ram_q80;
 pub mod state;
 pub mod infer;
 
@@ -13,11 +14,13 @@ use std::io::{prelude::*, stdout};
 
 use self::state::{RunStateView, TransformerWeightsView};
 
+#[derive(Debug)]
 pub struct View<'a, T: Storage> {
     pub data: &'a T,
     pub range: Range<usize>,
 }
 
+#[derive(Debug)]
 pub struct MutView<'a, MT> where MT: Storage {
     pub data: &'a mut MT,
     pub range: Range<usize>,
@@ -173,7 +176,7 @@ pub fn generate<'a, T: Storage, D: Device<T>>(cfg: &Config,
     steps: usize,
     topp: f32,
     wv: &TransformerWeightsView<'a, T>,
-    rsv: &mut RunStateView<'a, T>,
+    rsv: &mut RunStateView<'a, T, T>,
     device: &D
 ) -> io::Result<String>
     {
@@ -213,7 +216,7 @@ pub async fn generate_stream<'a, T: Storage, D: Device<T>>(cfg: &Config,
     steps: usize,
     topp: f32,
     wv: &TransformerWeightsView<'a, T>,
-    rsv: &mut RunStateView<'a, T>,
+    rsv: &mut RunStateView<'a, T, T>,
     device: &D,
     sender: Sender<Result<Event, Infallible>>
 ) {

--- a/engine/src/transformer/mod.rs
+++ b/engine/src/transformer/mod.rs
@@ -138,6 +138,7 @@ pub struct Config {
     pub vocab_size: usize,
     pub seq_len: usize,
     pub shared_weight: bool,
+    pub is_quantized: bool, // flag to tell if the model weights are quantized.
 }
 
 impl Config {
@@ -161,6 +162,7 @@ impl Config {
             },
             seq_len: read::<i32>(f) as usize,
             shared_weight: false,
+            is_quantized: false,
         };
         Self {
             shared_weight: shared_weight,

--- a/engine/src/transformer/mod.rs
+++ b/engine/src/transformer/mod.rs
@@ -172,7 +172,9 @@ impl Config {
             shared_weight: false,
             is_quantized: false,
         };
-        c.n_layers = 1;
+
+
+        // c.n_layers = 1; // REMOVE
         let shared_weight = read_byte(f) != 0;
         let _ = read::<i32>(f);
         Self {

--- a/engine/src/transformer/mod.rs
+++ b/engine/src/transformer/mod.rs
@@ -169,13 +169,13 @@ impl Config {
     }
 }
 
-pub fn generate<'a, T: Storage, D: Device<T>>(cfg: &Config,
+pub fn generate<'a, T: Storage, Q: Storage, D: Device<T, T>>(cfg: &Config,
     tokenizer: &Tokenizer,
     prompt: String,
     temperature: f32,
     steps: usize,
     topp: f32,
-    wv: &TransformerWeightsView<'a, T>,
+    wv: &TransformerWeightsView<'a, T, T>,
     rsv: &mut RunStateView<'a, T, T>,
     device: &D
 ) -> io::Result<String>
@@ -188,7 +188,7 @@ pub fn generate<'a, T: Storage, D: Device<T>>(cfg: &Config,
     let mut response = "".to_owned();
 
     while pos < steps {
-        forward(cfg, wv, rsv, token, pos, device);
+        forward::<T, Q, D>(cfg, wv, rsv, token, pos, device);
 
         if pos < prompt_tokens.len() {
             next = prompt_tokens[pos];
@@ -209,13 +209,13 @@ pub fn generate<'a, T: Storage, D: Device<T>>(cfg: &Config,
 }
 
 #[allow(dead_code)]
-pub async fn generate_stream<'a, T: Storage, D: Device<T>>(cfg: &Config,
+pub async fn generate_stream<'a, T: Storage, Q: Storage, D: Device<T, T>>(cfg: &Config,
     tokenizer: &Tokenizer,
     prompt: String,
     temperature: f32,
     steps: usize,
     topp: f32,
-    wv: &TransformerWeightsView<'a, T>,
+    wv: &TransformerWeightsView<'a, T, T>,
     rsv: &mut RunStateView<'a, T, T>,
     device: &D,
     sender: Sender<Result<Event, Infallible>>
@@ -228,7 +228,7 @@ pub async fn generate_stream<'a, T: Storage, D: Device<T>>(cfg: &Config,
     let mut response = "".to_owned();
 
     while pos < steps {
-        forward(cfg, wv, rsv, token, pos, device);
+        forward::<T, Q, D>(cfg, wv, rsv, token, pos, device);
 
         if pos < prompt_tokens.len() {
             next = prompt_tokens[pos];

--- a/engine/src/transformer/ram.rs
+++ b/engine/src/transformer/ram.rs
@@ -1,9 +1,9 @@
 use std::{fs::File, io::BufReader};
 
-use super::{read_vec, state::{RunState, TransformerWeights}, Config};
+use super::{ram_q80::QuantizedTensor, read_vec, state::{RunState, TransformerWeights}, Config};
 
 
-impl RunState<Vec<f32>, Vec<f32>> {
+impl RunState<Vec<f32>, Vec<QuantizedTensor>> {
     pub fn from_config(cfg: &Config) -> Self {
         let kv_dim = cfg.dim * cfg.n_kv_heads / cfg.n_heads;
         Self {
@@ -19,15 +19,15 @@ impl RunState<Vec<f32>, Vec<f32>> {
             logits: vec![0.0; cfg.vocab_size as usize],
             key_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
             value_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
-            xq: vec![0.0; cfg.dim as usize],
-            hq: vec![0.0; cfg.dim as usize],
+            xq: vec![QuantizedTensor::default(); cfg.dim as usize],
+            hq: vec![QuantizedTensor::default(); cfg.dim as usize],
         }
     }
 
 }
 
 impl TransformerWeights<Vec<f32>, Vec<f32>> {
-    pub fn from_file(f: &mut BufReader<File>, c: &Config) -> Self {
+    pub fn from_file(f: &mut BufReader<File>, c: &Config) -> TransformerWeights<Vec<f32>, Vec<f32>> {
         let head_size = c.dim / c.n_heads;
         Self {
             token_embedding_table: read_vec(f, c.vocab_size * c.dim),

--- a/engine/src/transformer/ram.rs
+++ b/engine/src/transformer/ram.rs
@@ -19,8 +19,8 @@ impl RunState<Vec<f32>, Vec<QuantizedTensor>> {
             logits: vec![0.0; cfg.vocab_size as usize],
             key_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
             value_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
-            xq: vec![QuantizedTensor::default(); cfg.dim as usize],
-            hq: vec![QuantizedTensor::default(); cfg.dim as usize],
+            xq: vec![QuantizedTensor { q: vec![0; cfg.dim], s: vec![0.0; cfg.dim / 64] }; 1],
+            hq: vec![QuantizedTensor { q: vec![0; cfg.dim], s: vec![0.0; cfg.hidden_dim / 64] }; 1],
         }
     }
 

--- a/engine/src/transformer/ram.rs
+++ b/engine/src/transformer/ram.rs
@@ -20,7 +20,7 @@ impl RunState<Vec<f32>, Vec<QuantizedTensor>> {
             key_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
             value_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
             xq: vec![QuantizedTensor { q: vec![0; cfg.dim], s: vec![0.0; cfg.dim / 64] }; 1],
-            hq: vec![QuantizedTensor { q: vec![0; cfg.dim], s: vec![0.0; cfg.hidden_dim / 64] }; 1],
+            hq: vec![QuantizedTensor { q: vec![0; cfg.hidden_dim], s: vec![0.0; cfg.hidden_dim / 64] }; 1],
         }
     }
 

--- a/engine/src/transformer/ram.rs
+++ b/engine/src/transformer/ram.rs
@@ -3,7 +3,7 @@ use std::{fs::File, io::BufReader};
 use super::{read_vec, state::{RunState, TransformerWeights}, Config};
 
 
-impl RunState<Vec<f32>> {
+impl RunState<Vec<f32>, Vec<f32>> {
     pub fn from_config(cfg: &Config) -> Self {
         let kv_dim = cfg.dim * cfg.n_kv_heads / cfg.n_heads;
         Self {
@@ -19,6 +19,8 @@ impl RunState<Vec<f32>> {
             logits: vec![0.0; cfg.vocab_size as usize],
             key_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
             value_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
+            xq: vec![0.0; cfg.dim as usize],
+            hq: vec![0.0; cfg.dim as usize],
         }
     }
 

--- a/engine/src/transformer/ram.rs
+++ b/engine/src/transformer/ram.rs
@@ -26,7 +26,7 @@ impl RunState<Vec<f32>, Vec<f32>> {
 
 }
 
-impl TransformerWeights<Vec<f32>> {
+impl TransformerWeights<Vec<f32>, Vec<f32>> {
     pub fn from_file(f: &mut BufReader<File>, c: &Config) -> Self {
         let head_size = c.dim / c.n_heads;
         Self {
@@ -49,6 +49,7 @@ impl TransformerWeights<Vec<f32>> {
                     read_vec::<f32>(f, c.vocab_size * c.dim)
                 }
             },
+            q_token: vec![1.0; c.vocab_size * c.dim],
         }
     }
 

--- a/engine/src/transformer/ram.rs
+++ b/engine/src/transformer/ram.rs
@@ -23,8 +23,30 @@ impl RunState<Vec<f32>, Vec<QuantizedTensor>> {
             hq: vec![QuantizedTensor { q: vec![0; cfg.hidden_dim], s: vec![0.0; cfg.hidden_dim / 64] }; 1],
         }
     }
-
 }
+
+impl RunState<Vec<f32>, Vec<f32>> {
+    pub fn from_config(cfg: &Config) -> Self {
+        let kv_dim = cfg.dim * cfg.n_kv_heads / cfg.n_heads;
+        Self {
+            x: vec![0.0; cfg.dim as usize],
+            xb: vec![0.0; cfg.dim as usize],
+            xb2: vec![0.0; cfg.dim as usize],
+            hb: vec![0.0; cfg.hidden_dim as usize],
+            hb2: vec![0.0; cfg.hidden_dim as usize],
+            q: vec![0.0; cfg.dim as usize],
+            k: vec![0.0; cfg.dim as usize],
+            v: vec![0.0; cfg.dim as usize],
+            att: vec![0.0; cfg.n_heads * cfg.seq_len as usize],
+            logits: vec![0.0; cfg.vocab_size as usize],
+            key_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
+            value_cache: vec![0.0; cfg.n_layers * cfg.seq_len * kv_dim as usize],
+            xq: vec![1.0; 1],
+            hq: vec![1.0; 1],
+        }
+    }
+}
+
 
 impl TransformerWeights<Vec<f32>, Vec<f32>> {
     pub fn from_file(f: &mut BufReader<File>, c: &Config) -> TransformerWeights<Vec<f32>, Vec<f32>> {

--- a/engine/src/transformer/ram_q80.rs
+++ b/engine/src/transformer/ram_q80.rs
@@ -40,7 +40,7 @@ fn read_q80_vec(rd: &mut BufReader<File>, n_layer: usize, size_each: usize) -> V
     (0..n_layer).map(|_| read_q80_tensor(rd, size_each)).collect()
 }
 
-impl TransformerWeights<Vec<f32>> {
+// impl TransformerWeights<Vec<f32>> {
     // #[allow(dead_code)]
     // pub fn from_file(f: &mut BufReader<File>, c: &Config) -> Self {
     //     let head_size = c.dim / c.n_heads;
@@ -77,4 +77,4 @@ impl TransformerWeights<Vec<f32>> {
 
     // }
 
-}
+// }

--- a/engine/src/transformer/ram_q80.rs
+++ b/engine/src/transformer/ram_q80.rs
@@ -1,0 +1,80 @@
+use std::{fs::File, io::{BufReader, Read}};
+
+use super::{read_vec, state::TransformerWeights, Config, Storage};
+
+// Each group (64) of tensors is stored in [i8; 64] + one f32 as scaling factor. Compression rate is about 4 * 64 / (1 * 64 + 4) ~= 4.
+#[repr(C)]
+#[derive(Debug, Clone, Default)]
+pub struct QuantizedTensor {
+    pub q: Vec<i8>, // quantized value
+    pub s: Vec<f32>, // scaling factor
+}
+
+impl Storage for QuantizedTensor {
+    fn length(&self) -> usize {
+        self.q.len()
+    }
+}
+
+const GS: i32 = 64;
+fn read_q80_tensor(rd: &mut BufReader<File>, size_each: usize) -> QuantizedTensor {
+    let mut qt = QuantizedTensor::default();
+    let s_size: i32 = size_each as i32 / GS;
+
+    qt.q = (0..size_each).map(|_| {
+            let mut buffer = [0u8; 1];
+            rd.read_exact(&mut buffer).expect("error reading file");
+            i8::from_le_bytes(buffer)
+        }
+    ).collect();
+    qt.s = (0..s_size).map(|_| {
+        let mut buffer = [0u8; 4];
+        rd.read_exact(&mut buffer).expect("error reading file");
+        f32::from_le_bytes(buffer)
+    }
+    ).collect();
+    qt
+}
+
+fn read_q80_vec(rd: &mut BufReader<File>, n_layer: usize, size_each: usize) -> Vec<QuantizedTensor> {
+    (0..n_layer).map(|_| read_q80_tensor(rd, size_each)).collect()
+}
+
+impl TransformerWeights<Vec<f32>> {
+    // #[allow(dead_code)]
+    // pub fn from_file(f: &mut BufReader<File>, c: &Config) -> Self {
+    //     let head_size = c.dim / c.n_heads;
+    //     let mut tw = Self {
+    //         // q_token: read_q80_vec(f, 1, c.vocab_size * c.dim),
+    //         token_embedding_table: vec![0.0f32; c.vocab_size * c.dim],
+    //         rms_att_weight: read_vec(f, c.n_layers * c.dim),
+    //         wq: read_q80_vec(f, c.n_layers, c.dim * c.dim),
+    //         wk: read_q80_vec(f, c.n_layers, c.dim * c.dim),
+    //         wv: read_q80_vec(f, c.n_layers, c.dim * c.dim),
+    //         wo: read_q80_vec(f, c.n_layers, c.dim * c.dim),
+    //         rms_ffn_weight: read_vec(f, c.n_layers * c.dim),
+    //         w1: read_q80_vec(f, c.n_layers, c.dim * c.hidden_dim),
+    //         w2: read_q80_vec(f, c.n_layers, c.dim * c.hidden_dim),
+    //         w3: read_q80_vec(f, c.n_layers, c.dim * c.hidden_dim),
+    //         rms_final_weight: read_vec(f, c.dim),
+    //         freq_cis_real: read_vec(f, c.seq_len * head_size / 2),
+    //         freq_cis_imag: read_vec(f, c.seq_len * head_size / 2),
+    //         wcls_exists: !c.shared_weight,
+    //         wcls: vec![],
+    //     };
+    //     tw.dequantize();
+    //     if c.shared_weight { tw.wcls = tw.q_token.clone(); } else {
+    //         read_q80_vec(f, 1, c.vocab_size * c.dim);
+    //     }
+    //     tw
+    // }
+
+    // // dequantize the token_embedding_table
+    // fn dequantize(&mut self) {
+    //     for i in 0..self.q_token[0].q.len() {
+    //         self.token_embedding_table[i] = self.q_token[0].q[i] as f32 * self.q_token[0].s[i / 64];
+    //     }
+
+    // }
+
+}

--- a/engine/src/transformer/ram_q80.rs
+++ b/engine/src/transformer/ram_q80.rs
@@ -3,6 +3,9 @@ use std::{fs::File, io::{BufReader, Read}};
 use super::{read_vec, state::TransformerWeights, Config, Storage};
 
 // Each group (64) of tensors is stored in [i8; 64] + one f32 as scaling factor. Compression rate is about 4 * 64 / (1 * 64 + 4) ~= 4.
+// It can be confusing why QuantizedTensor is also part of Vector in Weights.
+// Each layer -> QuantizedTensor, weights usually have multiple layers, so it is a vector.
+// Each QuantizedTensor is then equivalent to Vec<32> but quantized with a scale field.
 #[repr(C)]
 #[derive(Debug, Clone, Default)]
 pub struct QuantizedTensor {
@@ -52,7 +55,7 @@ impl TransformerWeights<Vec<f32>, Vec<QuantizedTensor>> {
             rms_att_weight: read_vec(f, c.n_layers * c.dim),
             rms_ffn_weight: read_vec(f, c.n_layers * c.dim),
             rms_final_weight: read_vec(f, c.dim),
-            q_token: vec![QuantizedTensor::default()],
+            q_token: read_q80_vec(f, 1, c.vocab_size * c.dim),
             wq: read_q80_vec(f, c.n_layers, c.dim * c.dim),
             wk: read_q80_vec(f, c.n_layers, c.dim * c.dim),
             wv: read_q80_vec(f, c.n_layers, c.dim * c.dim),
@@ -62,14 +65,14 @@ impl TransformerWeights<Vec<f32>, Vec<QuantizedTensor>> {
             w2: read_q80_vec(f, c.n_layers, c.dim * c.hidden_dim),
             w3: read_q80_vec(f, c.n_layers, c.dim * c.hidden_dim),
 
-            freq_cis_real: read_vec(f, c.seq_len * head_size / 2),
-            freq_cis_imag: read_vec(f, c.seq_len * head_size / 2),
+            freq_cis_real: vec![1.0f32; c.seq_len * head_size / 2],
+            freq_cis_imag: vec![1.0f32; c.seq_len * head_size / 2],
             wcls_exists: !c.shared_weight,
             wcls: vec![],
         };
         tw.dequantize();
         if c.shared_weight { tw.wcls = tw.q_token.clone(); } else {
-            read_q80_vec(f, 1, c.vocab_size * c.dim);
+            tw.wcls = read_q80_vec(f, 1, c.vocab_size * c.dim);
         }
         tw
     }

--- a/engine/src/transformer/ram_q80.rs
+++ b/engine/src/transformer/ram_q80.rs
@@ -16,7 +16,7 @@ pub struct QuantizedTensor {
 impl Storage for Vec<QuantizedTensor> {
     fn length(&self) -> usize {
         // TODO: I don't remember where the length is used now. Likely needs fixed.
-        self.len() * self[0].q.len()
+        self.len()
     }
 }
 

--- a/engine/src/transformer/state.rs
+++ b/engine/src/transformer/state.rs
@@ -84,27 +84,28 @@ pub struct TransformerWeights<T: Storage, Q: Storage> {
     pub wcls: Q,
 }
 
-pub struct TransformerWeightsView<'a, T: Storage> {
-    pub token_embedding_table: View<'a, T>,
+pub struct TransformerWeightsView<'a, T: Storage, Q: Storage> {
+    pub token_embedding_table: View<'a, Q>,
+    pub q_token: View<'a, Q>,
     pub rms_att_weight:  View<'a, T>,
     pub rms_ffn_weight: View<'a, T>,
-    pub wq: View<'a, T>,
-    pub wk: View<'a, T>,
-    pub wv: View<'a, T>,
-    pub wo: View<'a, T>,
-    pub w1: View<'a, T>,
-    pub w2: View<'a, T>,
-    pub w3: View<'a, T>,
+    pub wq: View<'a, Q>,
+    pub wk: View<'a, Q>,
+    pub wv: View<'a, Q>,
+    pub wo: View<'a, Q>,
+    pub w1: View<'a, Q>,
+    pub w2: View<'a, Q>,
+    pub w3: View<'a, Q>,
     pub rms_final_weight:View<'a, T>,
     pub freq_cis_real: View<'a, T>,
     pub freq_cis_imag: View<'a, T>,
     pub wcls_exists: bool,
-    pub wcls: View<'a, T>,
+    pub wcls: View<'a, Q>,
 }
 
-impl<'a> TransformerWeightsView<'a, Vec<f32>> {
+impl<'a> TransformerWeightsView<'a, Vec<f32>, Vec<f32>> {
     #[allow(dead_code)]
-    pub fn from_ws(ws: &'a TransformerWeights<Vec<f32>>) -> TransformerWeightsView<'a, Vec<f32>> {
+    pub fn from_ws(ws: &'a TransformerWeights<Vec<f32>, Vec<f32>>) -> TransformerWeightsView<'a, Vec<f32>, Vec<f32>> {
         TransformerWeightsView {
             token_embedding_table: View::new(&ws.token_embedding_table),
             rms_att_weight: View::new(&ws.rms_att_weight),
@@ -127,6 +128,7 @@ impl<'a> TransformerWeightsView<'a, Vec<f32>> {
                 }
             },
             wcls_exists: ws.wcls_exists,
+            q_token: View::new(&ws.q_token),
         }
 
     }

--- a/engine/src/transformer/state.rs
+++ b/engine/src/transformer/state.rs
@@ -85,7 +85,7 @@ pub struct TransformerWeights<T: Storage, Q: Storage> {
 }
 
 pub struct TransformerWeightsView<'a, T: Storage, Q: Storage> {
-    pub token_embedding_table: View<'a, Q>,
+    pub token_embedding_table: View<'a, T>,
     pub q_token: View<'a, Q>,
     pub rms_att_weight:  View<'a, T>,
     pub rms_ffn_weight: View<'a, T>,

--- a/engine/src/transformer/state.rs
+++ b/engine/src/transformer/state.rs
@@ -105,7 +105,7 @@ pub struct TransformerWeightsView<'a, T: Storage, Q: Storage> {
 
 impl<'a, T: Storage, Q: Storage> TransformerWeightsView<'a, T, Q> {
     #[allow(dead_code)]
-    pub fn from_ws(ws: &'a TransformerWeights<T, Q>) -> TransformerWeightsView<'a, T, Q> {
+    pub fn from_ws_q(ws: &'a TransformerWeights<T, Q>) -> TransformerWeightsView<'a, T, Q> {
         TransformerWeightsView {
             token_embedding_table: View::new(&ws.token_embedding_table),
             rms_att_weight: View::new(&ws.rms_att_weight),
@@ -129,6 +129,34 @@ impl<'a, T: Storage, Q: Storage> TransformerWeightsView<'a, T, Q> {
             },
             wcls_exists: ws.wcls_exists,
             q_token: View::new(&ws.q_token),
+        }
+
+    }
+
+    pub fn from_ws(ws: &'a TransformerWeights<T, T>) -> TransformerWeightsView<'a, T, T> {
+        TransformerWeightsView {
+            token_embedding_table: View::new(&ws.token_embedding_table),
+            rms_att_weight: View::new(&ws.rms_att_weight),
+            rms_ffn_weight: View::new(&ws.rms_ffn_weight),
+            wq: View::new(&ws.wq),
+            wk: View::new(&ws.wk),
+            wv: View::new(&ws.wv),
+            wo: View::new(&ws.wo),
+            w1: View::new(&ws.w1),
+            w2: View::new(&ws.w2),
+            w3: View::new(&ws.w3),
+            rms_final_weight: View::new(&ws.rms_final_weight),
+            freq_cis_real: View::new(&ws.freq_cis_real),
+            freq_cis_imag: View::new(&ws.freq_cis_imag),
+            wcls: {
+                if ws.wcls_exists {
+                    View::new(&ws.wcls)
+                } else {
+                    View::new(&ws.token_embedding_table)
+                }
+            },
+            wcls_exists: ws.wcls_exists,
+            q_token: View::new(&ws.token_embedding_table),
         }
 
     }

--- a/engine/src/transformer/state.rs
+++ b/engine/src/transformer/state.rs
@@ -103,9 +103,9 @@ pub struct TransformerWeightsView<'a, T: Storage, Q: Storage> {
     pub wcls: View<'a, Q>,
 }
 
-impl<'a> TransformerWeightsView<'a, Vec<f32>, Vec<f32>> {
+impl<'a, T: Storage, Q: Storage> TransformerWeightsView<'a, T, Q> {
     #[allow(dead_code)]
-    pub fn from_ws(ws: &'a TransformerWeights<Vec<f32>, Vec<f32>>) -> TransformerWeightsView<'a, Vec<f32>, Vec<f32>> {
+    pub fn from_ws(ws: &'a TransformerWeights<T, Q>) -> TransformerWeightsView<'a, T, Q> {
         TransformerWeightsView {
             token_embedding_table: View::new(&ws.token_embedding_table),
             rms_att_weight: View::new(&ws.rms_att_weight),
@@ -124,7 +124,7 @@ impl<'a> TransformerWeightsView<'a, Vec<f32>, Vec<f32>> {
                 if ws.wcls_exists {
                     View::new(&ws.wcls)
                 } else {
-                    View::new(&ws.token_embedding_table)
+                    View::new(&ws.q_token)
                 }
             },
             wcls_exists: ws.wcls_exists,

--- a/engine/src/utils/read.rs
+++ b/engine/src/utils/read.rs
@@ -28,6 +28,12 @@ pub(crate) fn read<T: FromBytes>(rd:&mut BufReader<File>) -> T {
     T::from_bytes(buffer)
 }
 
+pub(crate) fn read_byte(rd:&mut BufReader<File>) -> u8 {
+    let mut buffer = [0u8; 1];
+    rd.read_exact(&mut buffer).expect("error reading file");
+    u8::from_le_bytes(buffer)
+}
+
 pub fn read_vec<T: FromBytes>(rd: &mut BufReader<File>, size: usize) -> Vec<T> {
     (0..size).map(|_| read::<T>(rd)).collect()
 }


### PR DESCRIPTION
Support quantization for Rama. *for reference. It only supports quantization for CPU now.

TODO:

- [ ] fix build for GPU.
- [ ] support quantization for GPU.
- [ ] improve performance for quantization, add back `wide` ops.